### PR TITLE
This solves the mybinder.org issue with wrong dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 scipy
 pandas
 matplotlib
-sklearn
+scikit-learn
 collections
 math
 statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,4 @@ scipy
 pandas
 matplotlib
 scikit-learn
-collections2
-math
 statsmodels

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ scipy
 pandas
 matplotlib
 scikit-learn
-collections
+collections2
 math
 statsmodels


### PR DESCRIPTION
We exchanged all wrong dependencies in `requirements.txt` by the proper ones and threw out built-ins.