### PR TITLE
Change font families to avoid errors on mybinder

### DIFF
--- a/0_Data_Import_and_Visualisation.ipynb
+++ b/0_Data_Import_and_Visualisation.ipynb
@@ -72,7 +72,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import matplotlib as mpl\n",
-    "font = {'family' : 'Times New Roman',\n",
+    "font = {'family' : 'DejaVu Sans',\n",
     "        'weight' : 'normal',\n",
     "        'size'   : 13}\n",
     "mpl.rc('font', **font)"
@@ -352,7 +352,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "font = {'family' : 'Times New Roman',\n",
+    "font = {'family' : 'DejaVu Sans',\n",
     "        'weight' : 'normal',\n",
     "        'size'   : 20}\n",
     "mpl.rcParams['figure.figsize'] = (20,10)\n",

--- a/1_FFT_and_Reconstruction.ipynb
+++ b/1_FFT_and_Reconstruction.ipynb
@@ -41,7 +41,7 @@
     "from collections import OrderedDict\n",
     "\n",
     "import matplotlib as mpl\n",
-    "font = {'family' : 'Times New Roman',\n",
+    "font = {'family' : 'DejaVu Sans',\n",
     "        'weight' : 'normal',\n",
     "        'size'   : 20}\n",
     "mpl.rcParams['figure.figsize'] = (20,10)\n",


### PR DESCRIPTION
This PullRequest sets *DejaVu Sans* as new font for all plots generated by the notebooks [0_Data_Import_and_Visualisation.ipynb](https://github.com/harislulic/ZeMA-machine-learning-tutorials/blob/master/0_Data_Import_and_Visualisation.ipynb) and [1_FFT_and_Reconstruction.ipynb](https://github.com/harislulic/ZeMA-machine-learning-tutorials/blob/master/1_FFT_and_Reconstruction.ipynb) because the [mybinder.com](https://mybinder.org/v2/gh/harislulic/ZeMA-machine-learning-tutorials/master) Docker container does not have *Times New Roman* and produces an ugly error message before it falls back to *DejaVu Sans*. This will be avoided in the future if this commit is merged into *master*.